### PR TITLE
fix issue 8. The mbedtls library is built in non-production mode

### DIFF
--- a/c/rsa_sighash_all.c
+++ b/c/rsa_sighash_all.c
@@ -54,6 +54,11 @@
 #endif
 int md_string(const mbedtls_md_info_t *md_info, const unsigned char *buf,
               size_t n, unsigned char *output);
+
+int mbedtls_hardware_poll( void *data,
+                           unsigned char *output, size_t len, size_t *olen ) {
+  return 0;
+}
 /**
  * Note: there is no prefilled data for RSA, it's only be used in secp256k1.
  * Always succeed.

--- a/c/rsa_sighash_all.c
+++ b/c/rsa_sighash_all.c
@@ -55,8 +55,8 @@
 int md_string(const mbedtls_md_info_t *md_info, const unsigned char *buf,
               size_t n, unsigned char *output);
 
-int mbedtls_hardware_poll( void *data,
-                           unsigned char *output, size_t len, size_t *olen ) {
+int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len,
+                          size_t *olen) {
   return 0;
 }
 /**

--- a/deps/mbedtls-config-template.h
+++ b/deps/mbedtls-config-template.h
@@ -542,7 +542,7 @@
  * Requires MBEDTLS_ENTROPY_C, MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
  *
  */
-#define MBEDTLS_TEST_NULL_ENTROPY
+// #define MBEDTLS_TEST_NULL_ENTROPY
 
 /**
  * \def MBEDTLS_ENTROPY_HARDWARE_ALT
@@ -555,7 +555,7 @@
  *
  * Uncomment to use your own hardware entropy collector.
  */
-//#define MBEDTLS_ENTROPY_HARDWARE_ALT
+#define MBEDTLS_ENTROPY_HARDWARE_ALT
 
 /**
  * \def MBEDTLS_AES_ROM_TABLES


### PR DESCRIPTION
Provide an empty implementation of "mbedtls_hardware_poll", which makes the compiling process happy.
At the RSA verification phase, it's not used.
