### PR TITLE
fix: load secp256k1 data before using it

### DIFF
--- a/c/secp256k1_blake2b_sighash_all_lib.c
+++ b/c/secp256k1_blake2b_sighash_all_lib.c
@@ -74,6 +74,10 @@ validate_secp256k1_blake2b_sighash_all(const uint8_t *pubkey_hash,
   /* Load signature */
   secp256k1_context context;
   uint8_t secp_data[CKB_SECP256K1_DATA_SIZE];
+  ret = ckb_secp256k1_custom_load_data(secp_data);
+  if (ret != 0) {
+    return ret;
+  }
   ret = ckb_secp256k1_custom_verify_only_initialize(&context, secp_data);
   if (ret != 0) {
     return ret;


### PR DESCRIPTION
Fix secp256k1_blake2b_sighash_all_lib

In secp256k1_blake2b_sighash_all_dual.c:
```
  uint8_t secp_data[CKB_SECP256K1_DATA_SIZE];
  ret = ckb_secp256k1_custom_load_data(secp_data);
  if (ret != 0) {
    return ret;
  }
  ret = ckb_secp256k1_custom_verify_only_initialize(&context, secp_data);
  if (ret != 0) {
    return ret;
  }
```

But in secp256k1_blake2b_sighash_all_lib.c:
```
  uint8_t secp_data[CKB_SECP256K1_DATA_SIZE];
  ret = ckb_secp256k1_custom_verify_only_initialize(&context, secp_data);
  if (ret != 0) {
    return ret;
  }
```

So it doesn't work.